### PR TITLE
add a REPL-like console

### DIFF
--- a/lib/mvcli/console.rb
+++ b/lib/mvcli/console.rb
@@ -1,0 +1,58 @@
+require "mvcli"
+require "mvcli/app"
+require "readline"
+
+module MVCLI
+  class Console < MVCLI::App
+    include Readline
+
+    # Signature based on cucumber/aruba standard 
+    def initialize(argv, stdin=STDIN, stdout=STDOUT, stderr=STDERR, kernel=Kernel)
+      @argv, @stdin, @stdout, @stderr, @kernel = argv, stdin, stdout, stderr, kernel
+
+      # Interrupt handling
+      stty_save = `stty -g`.chomp
+      trap('INT') { system('stty', stty_save); exit }
+
+      # Readline config
+      Readline.completer_word_break_characters = ""
+      comp = proc { |s|
+        ssf = Readline.line_buffer[0, Readline.point]
+        possibilities = commands.grep( /^#{Regexp.escape(ssf)}/ )
+        suggestions = possibilities
+        last_word_break = ssf.rindex(/\s+/) || -1
+        suggestions = possibilities.map{|p| p[last_word_break+1, p.length]}
+        suggestions
+      }
+      Readline.completion_append_character = " "
+      Readline.completion_proc = comp
+      
+      super()
+    end
+
+    def commands
+      self.class.commands or []
+    end
+
+    class << self
+      attr_accessor :commands
+    end
+
+    def execute!
+      while cmd = readline_with_hist_management
+        result = call MVCLI::Command.new(cmd.split, nil, @stdout, @stderr, ENV.dup)
+        @stdout.puts "-> #{result}"
+      end
+      @kernel.exit 0
+    end
+
+    def readline_with_hist_management
+      line = Readline.readline('>> ', true)
+      return nil if line.nil?
+      if line =~ /^\s*$/ or Readline::HISTORY.to_a[-2] == line
+        Readline::HISTORY.pop
+      end
+      line
+    end
+  end
+end


### PR DESCRIPTION
@cowboyd and @krames: here's the console we chatted about recently.  It would have some advantages, especially for Rumm, since it can reuse the same connection across multiple commands.  Also makes turning Fog.mock! on easier in the future.

Plus, it has autocomplete and command history :)

This is what it should look like:

``` bash
>> create server
--> bootstrapping server serious-seance
    done.
created server: serious-seance
  id: 7e6eb96b-8768-34d4-7270-47b51a14b75e, password: asdfasdfasdf
-> 0
>> show servers
serious-seance -> id: 7e6eb96b-8768-34d4-7270-47b51a14b75e, status: ACTIVE, ipv4:
-> 0
```

And this is how it can be used:

``` ruby
#!/usr/bin/env ruby
# -*- mode: ruby -*-
require "mvcli/app"
require "mvcli/console"
require "rumm/version"

module Rumm
  class Console < MVCLI::Console
    self.root = Pathname(File.expand_path('../../', __FILE__))

    # It'd be nice if this was automatic based on routes
    commands = File.read(File.expand_path 'app/help/commands.txt', self.root)
    commands = commands.lines.select{|l| l =~ /rumm/}
    commands = commands.map{|c| c.gsub('rumm', '').strip}

    self.commands = commands
  end
end

console = Rumm::Console.new(ARGV.dup).execute!
```
